### PR TITLE
TAB-7894 e2e-tests: drop broken Chrome/chromedriver install

### DIFF
--- a/e2e-tests/action.yml
+++ b/e2e-tests/action.yml
@@ -164,22 +164,9 @@ runs:
       with:
         dotnet-version: ${{ inputs.dotnet-version }}
 
-    - name: Install GoogleChrome Driver
+    - name: Show Chrome/ChromeDriver versions
       run: |
-        google-chrome --version 
-        chromedriver --version
-        wget --no-verbose https://chromedriver.storage.googleapis.com/114.0.5735.90/chromedriver_linux64.zip
-        unzip chromedriver_linux64.zip
-        sudo mv chromedriver /usr/bin/chromedriver
-        sudo chown root:root /usr/bin/chromedriver
-        sudo chmod +x /usr/bin/chromedriver
-        wget --no-verbose https://mirror.cs.uchicago.edu/google-chrome/pool/main/g/google-chrome-stable/google-chrome-stable_126.0.6478.55-1_amd64.deb
-        wget --no-verbose http://archive.ubuntu.com/ubuntu/pool/main/libu/libu2f-host/libu2f-udev_1.1.10-1_all.deb
-        ls -l 
-        sudo dpkg -i libu2f-udev_1.1.10-1_all.deb
-        sudo dpkg -i google-chrome-stable_126.0.6478.55-1_amd64.deb
-        sudo apt-get install -fy
-        google-chrome --version 
+        google-chrome --version
         chromedriver --version
       shell: bash
 


### PR DESCRIPTION
## Summary

The `e2e-tests` composite action's "Install GoogleChrome Driver" step has been failing for ~47 minutes on every consuming PR (Tabula example: [run 27122493273](https://github.com/eScribers/tabula/actions/runs/27122493273/job/80045495872?pr=8428)), then exiting with code 4. The job log shows nothing but 21 × `failed: Connection timed out.` followed by the step giving up.

The root cause is in this composite action — three compounding problems:

1. **The uchicago mirror is unreachable** from the GHA runner. `wget` retries ~21 times on its default backoff (~2:15 each) until the step gives up. Recent commits in this repo (`Updated chrome download mirror`, `Updated google-chrome-stable mirror link`, `Updated Chrome mirror.`) have been chasing this — the underlying problem is the mirror dependency itself, not the choice of mirror.
2. **Even if the wget succeeded, the pin is broken.** chromedriver `114.0.5735.90` + Chrome `126.0.6478.55` is a 12-major-version mismatch that would produce the classic Selenium _"session not created"_ error.
3. **The whole step is dead code.** `ubuntu-latest` already ships matched Chrome + chromedriver preinstalled (148.0.7778.178 / 148.0.7778.178 on the most recent failed run, log lines 806-807). Selenium 4.x's Selenium Manager auto-resolves chromedriver to whatever Chrome is on the system — the manual install/overwrite is wasted work that would actively break the tests if it ever did finish.

## Fix

Replace the install step with a version-print-only step. Diagnostics in the job log are preserved; no external network dependency, no version pin to maintain.

## Changes

| File | Change |
|------|--------|
| `e2e-tests/action.yml` | Replace "Install GoogleChrome Driver" (15 lines of wget/dpkg) with "Show Chrome/ChromeDriver versions" (2 `--version` lines). |

## If pinning is needed later (out of scope here)

* [`browser-actions/setup-chrome@v1`](https://github.com/browser-actions/setup-chrome) — third-party GHA that installs a specific Chrome + matching chromedriver. Maintained, takes a version param, no flaky mirror.
* **Selenium Manager** — built into Selenium 4.11+. Auto-downloads the matching chromedriver. Already available to the .NET Selenium binding the tests use.

## Test plan

- [ ] Merge this PR and re-run the e2e job on Tabula PR #8428 (or any open PR).
- [ ] Confirm the "Show Chrome/ChromeDriver versions" step prints two `X.Y.Z` lines and finishes in <5s.
- [ ] Confirm the full e2e job completes in <10 minutes (vs. timing out at ~47 minutes).
- [ ] Confirm no `failed: Connection timed out.` lines anywhere in the job log.

Ticket: https://escribers.atlassian.net/browse/TAB-7894