### PR TITLE
TAB-7894 e2e-tests: pin Chrome 126 via browser-actions/setup-chrome

### DIFF
--- a/e2e-tests/action.yml
+++ b/e2e-tests/action.yml
@@ -164,6 +164,11 @@ runs:
       with:
         dotnet-version: ${{ inputs.dotnet-version }}
 
+    - name: Pin Chrome 126 (matches bundled Selenium.WebDriver.ChromeDriver)
+      uses: browser-actions/setup-chrome@v1
+      with:
+        chrome-version: 126.0.6478.55
+
     - name: Show Chrome/ChromeDriver versions
       run: |
         google-chrome --version


### PR DESCRIPTION
## Summary

Adds a `browser-actions/setup-chrome@v1` step that installs Chrome `126.0.6478.55` on the runner before the e2e tests run.

## Why

The runner's preinstalled Chrome 148 is incompatible with the `Selenium.WebDriver.ChromeDriver` NuGet bundled in `tabula-automation-tests`. Bumping that NuGet to chromedriver 148.* ([tabula-automation-tests#305](https://github.com/eScribers/tabula-automation-tests/pull/305)) was meant to fix it but exposed a Selenium 3.141.0 + chromedriver 148 wire-protocol incompatibility — Test 39 (`Jobs - Send a Message`) deterministically throws a near-empty `FATAL Exception` and the suite exits 255 ([failing job](https://github.com/eScribers/tabula/actions/runs/27129220261/job/80079161426)).

[tabula-automation-tests#306](https://github.com/eScribers/tabula-automation-tests/pull/306) reverts the NuGet bump back to chromedriver 126. This PR installs the matching Chrome 126 on the runner so the bundled chromedriver has a compatible browser. **Both PRs must merge for the e2e job to go green.**

## Why `browser-actions/setup-chrome@v1` (not dpkg from a mirror)

The previous install step used `wget` against `mirror.cs.uchicago.edu` and was hanging for 47 minutes when the mirror became unreachable — that's what motivated [#26](https://github.com/eScribers/workflow-actions-public/pull/26) to delete it. `browser-actions/setup-chrome` is a maintained GHA, takes a `chrome-version` input, and uses the official Chrome-for-Testing endpoints — no flaky mirror, no `dpkg` juggling.

## Changes

| File | Change |
|------|--------|
| `e2e-tests/action.yml` | +5 lines: new step `Pin Chrome 126` between `Setup .NET Core SDK` and `Show Chrome/ChromeDriver versions` |

## Test plan

- [ ] Merge this PR + [tabula-automation-tests#306](https://github.com/eScribers/tabula-automation-tests/pull/306).
- [ ] Re-run the e2e job on Tabula PR #8428.
- [ ] Confirm `Show Chrome/ChromeDriver versions` prints `Google Chrome 126.0.6478.55`.
- [ ] Confirm the suite reaches Test 44 (`General - Close Browser`) with `SUCCEEDED` status — i.e. parity with the last known-green run [27122491855](https://github.com/eScribers/tabula/actions/runs/27122491855).

## Permanent fix (out of scope)

Upgrade `Selenium.WebDriver` 3.141.0 → 4.x in `tabula-automation-tests`. Selenium 4.11+ ships Selenium Manager which auto-resolves chromedriver to whatever Chrome is on the system. Drops both this pin and the NuGet pin in one go. Worth its own ticket.

## Ticket

https://escribers.atlassian.net/browse/TAB-7894

🤖 Generated with [Claude Code](https://claude.com/claude-code)