### PR TITLE
TAB-7894 e2e-tests: symlink pinned Chrome into /usr/bin/google-chrome

### DIFF
--- a/e2e-tests/action.yml
+++ b/e2e-tests/action.yml
@@ -165,9 +165,16 @@ runs:
         dotnet-version: ${{ inputs.dotnet-version }}
 
     - name: Pin Chrome 126 (matches bundled Selenium.WebDriver.ChromeDriver)
+      id: chrome
       uses: browser-actions/setup-chrome@v1
       with:
         chrome-version: 126.0.6478.55
+
+    - name: Make pinned Chrome the system google-chrome
+      shell: bash
+      run: |
+        sudo ln -sf "${{ steps.chrome.outputs.chrome-path }}" /usr/bin/google-chrome
+        sudo ln -sf "${{ steps.chrome.outputs.chrome-path }}" /usr/bin/google-chrome-stable
 
     - name: Show Chrome/ChromeDriver versions
       run: |


### PR DESCRIPTION
## Summary

Forward-fix for [#27](https://github.com/eScribers/workflow-actions-public/pull/27). `browser-actions/setup-chrome@v1` installs the requested Chromium to `/opt/hostedtoolcache/setup-chrome/chromium/126.0.6478.55/x64/chrome` but does **not** replace `/usr/bin/google-chrome` — the runner's preinstalled Chrome 148 stays in PATH. NuGet-bundled chromedriver 126 then still tries to drive Chrome 148 and fails on session creation.

Symlink the action's `chrome-path` output over `/usr/bin/google-chrome` (and `-stable`) so the bundled chromedriver finds the matching browser version.

## Evidence from the failing run

Tabula run [27129220261 job 80088274743](https://github.com/eScribers/tabula/actions/runs/27129220261/job/80088274743) (after #27 + tabula-automation-tests#306 merged):

```
Successfully Installed chromium to /opt/hostedtoolcache/setup-chrome/chromium/126.0.6478.55/x64
...
Google Chrome 148.0.7778.178           ← system Chrome unchanged
ChromeDriver 148.0.7778.178
...
Starting ChromeDriver 126.0.6478.55    ← from NuGet bundle
[fails ~75s]
```

## Changes

| File | Change |
|------|--------|
| `e2e-tests/action.yml` | +7 lines: add `id: chrome` to the setup-chrome step; new step `Make pinned Chrome the system google-chrome` that `ln -sf`s the `chrome-path` output over `/usr/bin/google-chrome` + `/usr/bin/google-chrome-stable` |

## Test plan

- [ ] Merge.
- [ ] Re-run the e2e job on Tabula PR #8428.
- [ ] Confirm `Show Chrome/ChromeDriver versions` now prints `Google Chrome 126.0.6478.55` (not 148).
- [ ] Confirm Test 39 `Jobs - Send a Message` SUCCEEDED, suite reaches Test 44, job concludes success.

## Ticket

https://escribers.atlassian.net/browse/TAB-7894

🤖 Generated with [Claude Code](https://claude.com/claude-code)