### PR TITLE
TAB-7894 e2e-tests: diagnostic — try Chrome with/without --no-sandbox

### DIFF
--- a/e2e-tests/action.yml
+++ b/e2e-tests/action.yml
@@ -182,6 +182,23 @@ runs:
         chromedriver --version
       shell: bash
 
+    - name: TAB-7894 diagnostic — can Chrome launch with / without --no-sandbox?
+      shell: bash
+      run: |
+        set +e
+        echo "::group::chrome --headless (default flags)"
+        google-chrome --headless --disable-gpu --dump-dom https://example.com >/dev/null 2>&1
+        echo "exit=$?"
+        echo "::endgroup::"
+        echo "::group::chrome --headless --no-sandbox"
+        google-chrome --headless --no-sandbox --disable-gpu --dump-dom https://example.com >/dev/null 2>&1
+        echo "exit=$?"
+        echo "::endgroup::"
+        echo "::group::chrome --headless --no-sandbox stderr (last 40 lines)"
+        google-chrome --headless --no-sandbox --disable-gpu --dump-dom https://example.com 2>&1 >/dev/null | tail -40
+        echo "exit=$?"
+        echo "::endgroup::"
+
     - name: Build project
       run: |
         dotnet build


### PR DESCRIPTION
## Summary

**Diagnostic-only PR.** Adds one workflow step that tries to launch the pinned Chrome twice — once with default flags, once with `--no-sandbox` — and prints exit codes + stderr. The goal is to *prove or disprove* the sandbox hypothesis before patching `ChromeWebDriver.cs` in `tabula-automation-tests`.

## Why

The previous e2e failure surfaces as `One or more errors occurred. (The type initializer for 'Automation.Implementation.MirroredStructure.PageRoot' threw an exception.)` — an outer `AggregateException`/`TypeInitializationException` wrapping the actual Chrome session-creation error. The inner exception isn't logged anywhere we can see (`Logger.Fatal(e.Message)` only prints the outermost message). So I've been guessing at the root cause and shipping speculative fixes. Latest theory: Chromium-for-Testing (what `browser-actions/setup-chrome` zip-installs) lacks the setuid sandbox helper that Google Chrome's .deb ships, and Selenium fails to spawn the renderer.

This step will confirm or refute that in ~5s of CI time.

## What to look for in the run log

| `chrome --headless` exit | `chrome --headless --no-sandbox` exit | Conclusion |
|---|---|---|
| ≠ 0 | 0 | ✅ Sandbox hypothesis confirmed → apply `--no-sandbox` to `ChromeOptions` in tabula-automation-tests |
| 0 | 0 | ❌ Sandbox is fine → root cause is elsewhere |
| ≠ 0 | ≠ 0 | ❌ Chrome is just broken — look at stderr for the real error |

Plus the stderr tail block shows the actual Chrome error message in case both fail.

## Companion PR

[tabula-automation-tests#?](https://github.com/eScribers/tabula-automation-tests/pulls) — switches `Logger.Fatal(e.Message)` to `Logger.Fatal(e.ToString())` so the next FATAL Exception in TestPerformer.log includes the full inner-exception chain, not just the outermost wrapper. Independent improvement — would also work without this diagnostic PR.

## Test plan

- [ ] Merge.
- [ ] Re-run the e2e job on Tabula PR #8428.
- [ ] Look at the "TAB-7894 diagnostic" step output in the job log; record the two exit codes.
- [ ] Open a follow-up PR with the *actual* fix (almost certainly a small `ChromeOptions.AddArguments(...)` change in `tabula-automation-tests`), then revert this diagnostic step in workflow-actions-public.

## Will be removed

Once we know the answer, this step gets ripped out — it's not meant to live in production.

## Ticket

https://escribers.atlassian.net/browse/TAB-7894

🤖 Generated with [Claude Code](https://claude.com/claude-code)