### PR TITLE
TAB-7894 e2e-tests: remove sandbox-diagnostic step (job done)

### DIFF
--- a/e2e-tests/action.yml
+++ b/e2e-tests/action.yml
@@ -182,23 +182,6 @@ runs:
         chromedriver --version
       shell: bash
 
-    - name: TAB-7894 diagnostic — can Chrome launch with / without --no-sandbox?
-      shell: bash
-      run: |
-        set +e
-        echo "::group::chrome --headless (default flags)"
-        google-chrome --headless --disable-gpu --dump-dom https://example.com >/dev/null 2>&1
-        echo "exit=$?"
-        echo "::endgroup::"
-        echo "::group::chrome --headless --no-sandbox"
-        google-chrome --headless --no-sandbox --disable-gpu --dump-dom https://example.com >/dev/null 2>&1
-        echo "exit=$?"
-        echo "::endgroup::"
-        echo "::group::chrome --headless --no-sandbox stderr (last 40 lines)"
-        google-chrome --headless --no-sandbox --disable-gpu --dump-dom https://example.com 2>&1 >/dev/null | tail -40
-        echo "exit=$?"
-        echo "::endgroup::"
-
     - name: Build project
       run: |
         dotnet build


### PR DESCRIPTION
## Summary

Reverts the diagnostic step added in [#29](https://github.com/eScribers/workflow-actions-public/pull/29). It served its purpose — proved the chrome-sandbox hypothesis ([details on TAB-7894](https://escribers.atlassian.net/browse/TAB-7894)) — and the real fix is in [tabula-automation-tests#308](https://github.com/eScribers/tabula-automation-tests/pull/308). No need to keep running `chrome --headless --dump-dom example.com` on every consuming repo's PR.

## Changes

| File | Change |
|------|--------|
| `e2e-tests/action.yml` | -17 lines: drop the `TAB-7894 diagnostic` step between `Show Chrome/ChromeDriver versions` and `Build project` |

## Ticket

https://escribers.atlassian.net/browse/TAB-7894

🤖 Generated with [Claude Code](https://claude.com/claude-code)