### PR TITLE
TAB-7894 e2e-tests: also symlink /opt/google/chrome/chrome to pinned Chrome

### DIFF
--- a/e2e-tests/action.yml
+++ b/e2e-tests/action.yml
@@ -175,10 +175,14 @@ runs:
       run: |
         sudo ln -sf "${{ steps.chrome.outputs.chrome-path }}" /usr/bin/google-chrome
         sudo ln -sf "${{ steps.chrome.outputs.chrome-path }}" /usr/bin/google-chrome-stable
+        sudo mkdir -p /opt/google/chrome
+        sudo ln -sf "${{ steps.chrome.outputs.chrome-path }}" /opt/google/chrome/chrome
+        sudo ln -sf "${{ steps.chrome.outputs.chrome-path }}" /opt/google/chrome/google-chrome
 
     - name: Show Chrome/ChromeDriver versions
       run: |
-        google-chrome --version
+        /usr/bin/google-chrome --version
+        /opt/google/chrome/chrome --version
         chromedriver --version
       shell: bash
 


### PR DESCRIPTION
## Summary

Extends the symlink step (added in [#28](https://github.com/eScribers/workflow-actions-public/pull/28)) to cover `/opt/google/chrome/chrome` and `/opt/google/chrome/google-chrome` in addition to the `/usr/bin/google-chrome` paths.

## Why

ChromeDriver 126 ignores `/usr/bin/google-chrome` for binary resolution and goes straight to its hard-coded fallback path `/opt/google/chrome/chrome`. On the GHA `ubuntu-latest` runner that path is the preinstalled Google Chrome 148 `.deb`. So even though `/usr/bin/google-chrome` was symlinked to Chrome 126 by #28, chromedriver was still picking up Chrome 148 and trying to drive it — a 22-major-version mismatch.

## Evidence — stack trace from TestPerformer.log

After [tabula-automation-tests#307](https://github.com/eScribers/tabula-automation-tests/pull/307) made `Logger.Fatal` print full exception chains, the failing run on `tabula-automation-tests` PR #308 produced:

```
System.AggregateException: One or more errors occurred. (The type initializer for 'PageRoot' threw an exception.)
 ---> System.TypeInitializationException: The type initializer for 'PageRoot' threw an exception.
 ---> System.InvalidOperationException: session not created: Chrome failed to start: exited normally.
  (session not created: DevToolsActivePort file doesn't exist)
  (The process started from chrome location /opt/google/chrome/chrome is no longer running, so ChromeDriver is assuming that Chrome has crashed.) (SessionNotCreated)
   at OpenQA.Selenium.Chrome.ChromeDriver..ctor(...)
   at Automation.Framework.WebDrivers.BrowserDrivers.ChromeWebDriver.InitializeChromeDriver(ChromeOptions options) in ChromeWebDriver.cs:line 52
   at Automation.Framework.WebDrivers.BrowserDrivers.ChromeWebDriver..ctor() in ChromeWebDriver.cs:line 20
   at Automation.Framework.Management.BrowsersManagement.BrowserManager.get_DriverInternal() in BrowserManager.cs:line 22
   at Automation.Implementation.MirroredStructure.PageRoot..cctor() in PageRoot.cs:line 30
```

The `chrome location /opt/google/chrome/chrome` line is the definitive evidence — chromedriver bypasses `/usr/bin` entirely.

The earlier sandbox-crash signature from the diagnostic step was a *different* Chrome binary (Chromium 126 at `/usr/bin/google-chrome`) — a real but unrelated issue. [tabula-automation-tests#308](https://github.com/eScribers/tabula-automation-tests/pull/308) addressed it (`--no-sandbox` in ChromeOptions) and that fix still stands, but it wasn't what was breaking PageRoot.

## Changes

| File | Change |
|------|--------|
| `e2e-tests/action.yml` | +5 lines: also symlink `/opt/google/chrome/chrome` and `/opt/google/chrome/google-chrome` to the pinned Chrome binary; print versions from both `/usr/bin` and `/opt/google/chrome` so the next failure is unambiguous |

## Test plan

- [ ] Merge.
- [ ] Re-run the e2e job on Tabula PR #8428 (or push a no-op commit to `tabula-automation-tests` PR #308 to retrigger its own CI).
- [ ] Confirm the `Show Chrome/ChromeDriver versions` step prints `Google Chrome for Testing 126.0.6478.55` from **both** `/usr/bin/google-chrome` and `/opt/google/chrome/chrome`.
- [ ] Confirm PageRoot's static ctor no longer throws; tests reach Test 1+.

## Ticket

https://escribers.atlassian.net/browse/TAB-7894

🤖 Generated with [Claude Code](https://claude.com/claude-code)