### PR TITLE
TAB-7897 e2e-tests: publish reports to GH Artifacts (+ FATAL step summary)

### DIFF
--- a/e2e-tests/action.yml
+++ b/e2e-tests/action.yml
@@ -205,6 +205,29 @@ runs:
         shell: bash
         command: ./TestPerformer/bin/Debug/net6.0/TestPerformer load ./Automation.Tests/bin/Debug/netcoreapp3.1/Automation.Tests.dll // run ./common/TestSuites/SmokeE2E/${{ inputs.test-suite }}
 
+    - name: Surface FATAL in step summary
+      if: failure()
+      shell: bash
+      run: |
+        LATEST=$(ls -td ./TestPerformer/bin/Debug/net6.0/Reports/*/ 2>/dev/null | head -1)
+        if [ -n "$LATEST" ] && [ -f "${LATEST}TestPerformer.log" ]; then
+          {
+            echo "### Last failure (from TestPerformer.log)"
+            echo '```'
+            grep -A 50 -B 2 "FATAL" "${LATEST}TestPerformer.log" | tail -80
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+        fi
+
+    - name: Upload test reports (GH artifact)
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: e2e-reports-${{ github.run_id }}-${{ github.run_attempt }}
+        path: ./TestPerformer/bin/Debug/net6.0/Reports/
+        retention-days: 30
+        if-no-files-found: warn
+
     - name: Add credentials to Amazon
       uses: "aws-actions/configure-aws-credentials@v4"
       if: always()

--- a/e2e-tests/action.yml
+++ b/e2e-tests/action.yml
@@ -207,9 +207,13 @@ runs:
 
     - name: Surface FATAL in step summary
       if: failure()
+      continue-on-error: true
       shell: bash
       run: |
-        LATEST=$(ls -td ./TestPerformer/bin/Debug/net6.0/Reports/*/ 2>/dev/null | head -1)
+        # Diagnostics only — must never look like an extra failure. The || true
+        # guards the pipefail when Reports/ doesn't exist yet (job failed
+        # before TestPerformer ran).
+        LATEST=$(ls -td ./TestPerformer/bin/Debug/net6.0/Reports/*/ 2>/dev/null | head -1 || true)
         if [ -n "$LATEST" ] && [ -f "${LATEST}TestPerformer.log" ]; then
           EXCERPT=$(grep -A 50 -B 2 "FATAL" "${LATEST}TestPerformer.log" 2>/dev/null | tail -80 || true)
           if [ -n "$EXCERPT" ]; then
@@ -224,6 +228,9 @@ runs:
 
     - name: Upload test reports (GH artifact)
       if: always()
+      # Diagnostics must not be load-bearing: a transient artifact-service
+      # failure must never turn a green test run red.
+      continue-on-error: true
       uses: actions/upload-artifact@v4
       with:
         name: e2e-reports-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.test-suite }}

--- a/e2e-tests/action.yml
+++ b/e2e-tests/action.yml
@@ -211,19 +211,22 @@ runs:
       run: |
         LATEST=$(ls -td ./TestPerformer/bin/Debug/net6.0/Reports/*/ 2>/dev/null | head -1)
         if [ -n "$LATEST" ] && [ -f "${LATEST}TestPerformer.log" ]; then
-          {
-            echo "### Last failure (from TestPerformer.log)"
-            echo '```'
-            grep -A 50 -B 2 "FATAL" "${LATEST}TestPerformer.log" | tail -80
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
+          EXCERPT=$(grep -A 50 -B 2 "FATAL" "${LATEST}TestPerformer.log" 2>/dev/null | tail -80 || true)
+          if [ -n "$EXCERPT" ]; then
+            {
+              echo "### Last failure (from TestPerformer.log)"
+              echo '```'
+              echo "$EXCERPT"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
         fi
 
     - name: Upload test reports (GH artifact)
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: e2e-reports-${{ github.run_id }}-${{ github.run_attempt }}
+        name: e2e-reports-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.test-suite }}
         path: ./TestPerformer/bin/Debug/net6.0/Reports/
         retention-days: 30
         if-no-files-found: warn


### PR DESCRIPTION
## Summary

Adds two steps to the e2e composite action, after `Run tests` and before the existing S3 upload (which is kept untouched for now):

1. **`Surface FATAL in step summary`** (runs `if: failure()`) — greps the latest `TestPerformer.log` for the `FATAL` line plus surrounding context (50 lines after, 2 before, last 80 lines of the match) and writes it to `$GITHUB_STEP_SUMMARY`. Result: the cause of an e2e failure shows inline on the run page, no artifact download needed.

2. **`Upload test reports (GH artifact)`** (runs `if: always()`) — uses `actions/upload-artifact@v4` with `retention-days: 30` and a name incorporating `github.run_id` + `github.run_attempt` to avoid collisions across re-runs. Anyone with repo read access can download from the run page; **no AWS creds required**.

## Why now

Motivated by [TAB-7894](https://escribers.atlassian.net/browse/TAB-7894): twice I had to ask Daniel to pull a log file off S3 mid-investigation because I had no direct access. The `TestPerformer.log` we eventually needed (showing the actual inner-exception stack trace under the masked outer message) was sitting in `s3://escribers-automation-tests-e2e-reports/_06_08_12_17_7608/` — invisible to anyone outside the AWS-credential holders. With this change that file would have been one click from the failed check.

## Why both alongside S3 (not S3 replaced)

[TAB-7897 description](https://escribers.atlassian.net/browse/TAB-7897) covers this — Phase 1 (this PR) runs both in parallel. Phase 2 (separate ticket later) removes the S3 step once we've confirmed:

- 30-day retention is enough for our debugging workflow
- The zip-bundle UX is acceptable
- No external tooling secretly reads from `s3://escribers-automation-tests-e2e-reports/`

That way roll-back is a one-revert if the GH artifact UX disappoints, and downstream consumers of the S3 bucket aren't disrupted on day 1.

## Changes

| File | Change |
|------|--------|
| `e2e-tests/action.yml` | +23 lines: two new steps inserted between `Run tests` and the existing AWS-credentials + S3 upload steps. No removals. |

## Test plan

- [ ] Merge.
- [ ] Push a no-op commit on any consuming repo's PR (tabula PR #8429 or a tabula-automation-tests PR) to trigger an e2e run.
- [ ] Confirm an "Artifacts" panel appears on the run page with a downloadable `e2e-reports-NNNNN-N` archive containing the same files we currently upload to S3.
- [ ] Confirm the existing S3 upload still runs successfully (parity, no regression).
- [ ] On a deliberately-failing run (or wait for the next real failure), confirm a "Last failure (from TestPerformer.log)" section appears in the run's summary panel with the FATAL excerpt.

## Risks (small)

- **Storage budget** — GHA Artifacts: 10 GB free / $0.25/GB/mo beyond for private repos. The reports we saw on TAB-7894 were a few KB each (TestPerformer.log + subtitles.log + maybe screenshots). Nowhere near the limit. Worth monitoring after a sprint of real usage.
- **`if-no-files-found: warn`** — chose `warn` over `error` so an early-pipeline failure (where Reports/ may be absent) doesn't fail the upload step. If the Reports directory is missing we just warn and move on.
- **Naming collisions** — addressed by the `${{ github.run_id }}-${{ github.run_attempt }}` suffix.

## Out of scope

- Removing the S3 upload (Phase 2, separate ticket).
- Restructuring the report directory layout.
- Any change to the S3 bucket or its retention.

## Ticket

https://escribers.atlassian.net/browse/TAB-7897

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TAB-7894]: https://escribers.atlassian.net/browse/TAB-7894?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ